### PR TITLE
Add default importability setting

### DIFF
--- a/docs/rule-jsdoc.md
+++ b/docs/rule-jsdoc.md
@@ -12,7 +12,8 @@ As a bonus feature, importing exports annotated with `@private` is always forbid
   "rules": {
     "import-access/jsdoc": ["error", {
       "indexLoophole": true,
-      "filenameLoophole": false
+      "filenameLoophole": false,
+      "defaultImportability": "public" // "public" | "package" | "private"
     }],
   }
 ```
@@ -45,6 +46,7 @@ The `import-access/jsdoc` rule has following options and default values:
 type JSDocRuleOptions = {
   indexLoophole: boolean;
   filenameLoophole: boolean;
+  defaultImportability: "public" | "pacakge" | "private";
 };
 ```
 
@@ -98,4 +100,27 @@ import { pika } from "./sub/foo";
 // This is still INCORRECT because file name does not match
 // the directory name
 import { pika } from "./sub/foo";
+```
+
+### `defaultImportability`
+
+_Default value: `public`_
+
+You can set default importability value for apply entire your project.
+
+**Example:**
+
+```ts
+// defaultImportability: "package"
+// ----- sub/bar.ts
+
+export const pika = "chu"; // no JSDoc, but automatically applied @package
+
+// ----- sub/foo.ts
+// you can import 
+import { pika } from "./bar";
+
+// ----- bar2.ts
+// you cannot import because pika is @package 
+import { pika } from "./sub/bar`;
 ```

--- a/docs/ts-server.md
+++ b/docs/ts-server.md
@@ -28,7 +28,8 @@ In addition, options can be provided to the plugin:
         "name": "eslint-plugin-import-access",
         "jsdoc": {
           "indexLoophole": false,
-          "filenameLoophole": true
+          "filenameLoophole": true,
+          "defaultImportability": "package"
         }
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-import-access",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-import-access",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^5.9.1",

--- a/src/__tests__/default-export.ts
+++ b/src/__tests__/default-export.ts
@@ -32,4 +32,92 @@ describe("default export", () => {
       ]
     `);
   });
+  it("Cannot import package when jsDoc is not declared from sub directory with defaultImportability=package", async () => {
+    const result = await tester.lintFile("src/default-export/foo.ts", {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "column": 8,
+          "endColumn": 12,
+          "endLine": 1,
+          "line": 1,
+          "message": "Cannot import a package-private export 'default'",
+          "messageId": "package",
+          "nodeType": "ImportDefaultSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+        Object {
+          "column": 8,
+          "endColumn": 11,
+          "endLine": 2,
+          "line": 2,
+          "message": "Cannot import a package-private export 'default'",
+          "messageId": "package",
+          "nodeType": "ImportDefaultSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+        Object {
+          "column": 10,
+          "endColumn": 25,
+          "endLine": 4,
+          "line": 4,
+          "message": "Cannot import a package-private export 'default'",
+          "messageId": "package",
+          "nodeType": "ImportSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+      ]
+    `);
+  });
+  it("Cannot import package when jsDoc is not declared from sub directory with defaultImportability=private", async () => {
+    const result = await tester.lintFile("src/default-export/foo.ts", {
+      jsdoc: {
+        defaultImportability: "private",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "column": 8,
+          "endColumn": 12,
+          "endLine": 1,
+          "line": 1,
+          "message": "Cannot import a package-private export 'default'",
+          "messageId": "package",
+          "nodeType": "ImportDefaultSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+        Object {
+          "column": 8,
+          "endColumn": 11,
+          "endLine": 2,
+          "line": 2,
+          "message": "Cannot import a private export 'default'",
+          "messageId": "private",
+          "nodeType": "ImportDefaultSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+        Object {
+          "column": 10,
+          "endColumn": 25,
+          "endLine": 4,
+          "line": 4,
+          "message": "Cannot import a package-private export 'default'",
+          "messageId": "package",
+          "nodeType": "ImportSpecifier",
+          "ruleId": "import-access/jsdoc",
+          "severity": 2,
+        },
+      ]
+    `);
+  });
 });

--- a/src/__tests__/fixtures/project/src/reexport3/sub.ts
+++ b/src/__tests__/fixtures/project/src/reexport3/sub.ts
@@ -1,0 +1,5 @@
+import { subFoo } from "./sub/foo";
+import { subBar } from "./sub2/bar";
+
+// Cannot import subBar with packageOptions.defaultImportability=package
+console.log(subFoo, subBar);

--- a/src/__tests__/fixtures/project/src/reexport3/sub/foo.ts
+++ b/src/__tests__/fixtures/project/src/reexport3/sub/foo.ts
@@ -1,0 +1,4 @@
+/**
+ * @public
+ */
+export const subFoo = "hello!";

--- a/src/__tests__/fixtures/project/src/reexport3/sub2/bar.ts
+++ b/src/__tests__/fixtures/project/src/reexport3/sub2/bar.ts
@@ -1,0 +1,1 @@
+export const subBar = "BAR";

--- a/src/__tests__/reexport.ts
+++ b/src/__tests__/reexport.ts
@@ -103,4 +103,28 @@ Array [
 `);
     });
   });
+  describe("defaultImportability=package", () => {
+    it("Cannot import no JSDocs from sub directory", async () => {
+      const result = await tester.lintFile("src/reexport3/sub.ts", {
+        jsdoc: {
+          defaultImportability: "package",
+        },
+      });
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "column": 10,
+            "endColumn": 16,
+            "endLine": 2,
+            "line": 2,
+            "message": "Cannot import a package-private export 'subBar'",
+            "messageId": "package",
+            "nodeType": "ImportSpecifier",
+            "ruleId": "import-access/jsdoc",
+            "severity": 2,
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/src/core/checkSymbolmportability.ts
+++ b/src/core/checkSymbolmportability.ts
@@ -3,8 +3,8 @@ import { assertNever } from "../utils/assertNever";
 import { concatArrays } from "../utils/concatArrays";
 import { findExportedDeclaration } from "../utils/findExportableDeclaration";
 import { getAccessOfJsDocs } from "../utils/getAccessOfJsDocs";
-import { getJSDocTags, Tag } from "../utils/getJSDocTags";
-import { isInPackage, PackageOptions } from "../utils/isInPackage";
+import { Tag, getJSDocTags } from "../utils/getJSDocTags";
+import { PackageOptions, isInPackage } from "../utils/isInPackage";
 
 /**
  * Result of checking a symbol.
@@ -36,7 +36,20 @@ export function checkSymbolImportability(
     getJSDocTags(decl)
   );
   if (!jsDocs) {
-    return;
+    switch (packageOptions.defaultImportability) {
+      case "public":
+        return;
+      case "private":
+        return "private";
+      case "package": {
+        const inPackage = isInPackage(
+          importerFilename,
+          decl.getSourceFile().fileName,
+          packageOptions
+        );
+        return inPackage ? undefined : "package";
+      }
+    }
   }
   const access = getAccessOfJsDocs(jsDocs);
   if (access === "public") {

--- a/src/core/checkSymbolmportability.ts
+++ b/src/core/checkSymbolmportability.ts
@@ -51,7 +51,7 @@ export function checkSymbolImportability(
       }
     }
   }
-  const access = getAccessOfJsDocs(jsDocs);
+  const access = getAccessOfJsDocs(jsDocs, packageOptions.defaultImportability);
   if (access === "public") {
     // no restriction
     return;

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -15,6 +15,10 @@ export type JSDocRuleOptions = {
    * Whether importing a package-private exports in a directory from a file of same name.
    */
   filenameLoophole: boolean;
+  /**
+   * Whether packages importability is restricted to public exports only or not.
+   */
+  defaultImportability: "public" | "package" | "private";
 };
 
 const jsdocRule: Omit<
@@ -42,6 +46,10 @@ const jsdocRule: Omit<
           filenameLoophole: {
             type: "boolean",
           },
+          defaultImportability: {
+            type: "string",
+            enum: ["public", "package", "private"],
+          },
         },
         additionalProperties: false,
       },
@@ -52,11 +60,14 @@ const jsdocRule: Omit<
     if (!parserServices) {
       return {};
     }
-    const { indexLoophole, filenameLoophole } = jsDocRuleDefaultOptions(
-      options[0]
-    );
+    const { indexLoophole, filenameLoophole, defaultImportability } =
+      jsDocRuleDefaultOptions(options[0]);
 
-    const packageOptions: PackageOptions = { indexLoophole, filenameLoophole };
+    const packageOptions: PackageOptions = {
+      indexLoophole,
+      filenameLoophole,
+      defaultImportability,
+    };
 
     return {
       ImportSpecifier(node) {
@@ -90,8 +101,12 @@ export default jsdocRule;
 export function jsDocRuleDefaultOptions(
   options: Partial<JSDocRuleOptions> | undefined
 ): JSDocRuleOptions {
-  const { indexLoophole = true, filenameLoophole = false } = options || {};
-  return { indexLoophole, filenameLoophole };
+  const {
+    indexLoophole = true,
+    filenameLoophole = false,
+    defaultImportability = "public",
+  } = options || {};
+  return { indexLoophole, filenameLoophole, defaultImportability };
 }
 
 function checkSymbol(

--- a/src/utils/getAccessOfJsDocs.ts
+++ b/src/utils/getAccessOfJsDocs.ts
@@ -5,7 +5,10 @@ export type JSDocAccess = "public" | "package" | "private";
 /**
  * Get access for given JSDoc.
  */
-export function getAccessOfJsDocs(tags: readonly Tag[]): JSDocAccess {
+export function getAccessOfJsDocs(
+  tags: readonly Tag[],
+  defaultImportability: JSDocAccess
+): JSDocAccess {
   for (const tag of tags) {
     const tagName = tag.name;
     if (tagName === "package") {
@@ -15,6 +18,10 @@ export function getAccessOfJsDocs(tags: readonly Tag[]): JSDocAccess {
     if (tagName === "private") {
       // @private
       return "private";
+    }
+    if (tagName === "public") {
+      // @public
+      return "public";
     }
     if (tagName === "access") {
       // @access
@@ -27,7 +34,11 @@ export function getAccessOfJsDocs(tags: readonly Tag[]): JSDocAccess {
         // @access private
         return "private";
       }
+      if (text === "public") {
+        // @access public
+        return "public";
+      }
     }
   }
-  return "public";
+  return defaultImportability;
 }

--- a/src/utils/isInPackage.ts
+++ b/src/utils/isInPackage.ts
@@ -3,6 +3,7 @@ import path from "path";
 export type PackageOptions = {
   readonly indexLoophole: boolean;
   readonly filenameLoophole: boolean;
+  readonly defaultImportability: "public" | "package" | "private";
 };
 
 // ../ or ../../ or ...


### PR DESCRIPTION
## Summary
Add default importability setting for applying @package or @private to entire project without adding JSDoc.

I think it's similar thought with https://github.com/uhyo/eslint-plugin-import-access/issues/2.

Sorry for the sudden, but I hope you take a look when you have time!