### PR TITLE
Fix issue of node_modules package

### DIFF
--- a/src/__tests__/default-export.ts
+++ b/src/__tests__/default-export.ts
@@ -120,4 +120,12 @@ describe("default export", () => {
       ]
     `);
   });
+  it("No error for node_modules with defaultImportability=package", async () => {
+    const result = await tester.lintFile("src/default-export2/foo.ts", {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/src/__tests__/fixtures/project/src/default-export2/foo.ts
+++ b/src/__tests__/fixtures/project/src/default-export2/foo.ts
@@ -1,0 +1,3 @@
+import * as tsLintUtils from "@typescript-eslint/experimental-utils";
+
+console.log(tsLintUtils);

--- a/src/__tests__/fixtures/project/src/reexport3/sub3/sub.ts
+++ b/src/__tests__/fixtures/project/src/reexport3/sub3/sub.ts
@@ -1,0 +1,5 @@
+import { TSESLint } from "@typescript-eslint/experimental-utils";
+import { subBar } from "../sub2/bar";
+
+console.log(TSESLint);
+console.log(subBar);

--- a/src/__tests__/reexport.ts
+++ b/src/__tests__/reexport.ts
@@ -127,4 +127,26 @@ Array [
       `);
     });
   });
+  it("No error for node_modules with defaultImportability=package", async () => {
+    const result = await tester.lintFile("src/reexport3/sub3/sub.ts", {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "column": 10,
+            "endColumn": 16,
+            "endLine": 2,
+            "line": 2,
+            "message": "Cannot import a package-private export 'subBar'",
+            "messageId": "package",
+            "nodeType": "ImportSpecifier",
+            "ruleId": "import-access/jsdoc",
+            "severity": 2,
+          },
+        ]
+      `);
+  });
 });

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -127,8 +127,12 @@ function checkNodeModulesPackageOrNot(
     const packageName = node.parent.source.value;
 
     try {
-      require.resolve(packageName);
-      return true;
+      const packagePath = require.resolve(packageName);
+      if (packagePath.includes("node_modules")) {
+        return true;
+      }
+
+      return false;
     } catch (e) {
       return false;
     }

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -71,6 +71,12 @@ const jsdocRule: Omit<
 
     return {
       ImportSpecifier(node) {
+        const isNodeModules = checkNodeModulesPackageOrNot(node);
+        // ignore node_modules
+        if (isNodeModules) {
+          return;
+        }
+
         const checker = parserServices.program.getTypeChecker();
 
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
@@ -81,6 +87,11 @@ const jsdocRule: Omit<
         }
       },
       ImportDefaultSpecifier(node) {
+        const isNodeModules = checkNodeModulesPackageOrNot(node);
+        // ignore node_modules
+        if (isNodeModules) {
+          return;
+        }
         const checker = parserServices.program.getTypeChecker();
 
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
@@ -107,6 +118,21 @@ export function jsDocRuleDefaultOptions(
     defaultImportability = "public",
   } = options || {};
   return { indexLoophole, filenameLoophole, defaultImportability };
+}
+
+function checkNodeModulesPackageOrNot(
+  node: TSESTree.ImportSpecifier | TSESTree.ImportDefaultSpecifier
+) {
+  if (node.parent?.type === "ImportDeclaration") {
+    const packageName = node.parent.source.value;
+
+    try {
+      require.resolve(packageName);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 function checkSymbol(


### PR DESCRIPTION
When defaultImportability=package, eslint shows error of import-access.
But in the most cases, a package from node_modules should not be restricted access.

So I fix it. Sorry.