### PR TITLE
Fix another issue of imports from node_modules

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
+      - run: npm i -g npm@9
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14, 16]
+        npm-version: [9]
         ts-version: [4.4, 4.5]
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm i -g npm@${{ matrix.npm-version }}
       - run: npm ci
       - run: npm install -D typescript@${{ matrix.ts-version }}
       - run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+install-links=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7908,6 +7908,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "src/__tests__/fixtures/packages/missing_entrypoint": {
+      "name": "@fixture-package/missing-entrypoint",
+      "extraneous": true
     }
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-import-access",
-  "version": "1.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-import-access",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^5.9.1",
@@ -17,6 +17,7 @@
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-typescript": "^7.14.5",
+        "@fixture-package/missing-entrypoint": "file:src/__tests__/fixtures/packages/missing_entrypoint",
         "@types/jest": "^27.4.0",
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
@@ -1731,6 +1732,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@fixture-package/missing-entrypoint": {
+      "resolved": "file:src/__tests__/fixtures/packages/missing_entrypoint",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.2",
@@ -9090,6 +9095,9 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@fixture-package/missing-entrypoint": {
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-typescript": "^7.14.5",
+    "@fixture-package/missing-entrypoint": "file:src/__tests__/fixtures/packages/missing_entrypoint",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",

--- a/src/__tests__/default-export.ts
+++ b/src/__tests__/default-export.ts
@@ -128,4 +128,12 @@ describe("default export", () => {
     });
     expect(result).toMatchInlineSnapshot(`Array []`);
   });
+  it("No error for node_modules with defaultImportability=package even if package entrypoint is missing", async () => {
+    const result = await tester.lintFile("src/default-export3/foo.ts", {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/src/__tests__/fixtures/packages/missing_entrypoint/index.d.ts
+++ b/src/__tests__/fixtures/packages/missing_entrypoint/index.d.ts
@@ -1,0 +1,1 @@
+export type Foo = "foo";

--- a/src/__tests__/fixtures/packages/missing_entrypoint/package.json
+++ b/src/__tests__/fixtures/packages/missing_entrypoint/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixture-package/missing-entrypoint",
+  "types": "index.d.ts"
+}

--- a/src/__tests__/fixtures/project/src/default-export3/foo.ts
+++ b/src/__tests__/fixtures/project/src/default-export3/foo.ts
@@ -1,0 +1,4 @@
+import { Foo } from "@fixture-package/missing-entrypoint";
+
+const foo: Foo = "foo";
+console.log(foo);

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -125,17 +125,19 @@ function checkNodeModulesPackageOrNot(
 ) {
   if (node.parent?.type === "ImportDeclaration") {
     const packageName = node.parent.source.value;
-
-    try {
-      const packagePath = require.resolve(packageName);
-      if (packagePath.includes("node_modules")) {
-        return true;
-      }
-
-      return false;
-    } catch (e) {
-      return false;
+    if (willBeImportedFromNodeModules(packageName)) {
+      return true;
     }
+    return willBeImportedFromNodeModules(`${packageName}/package.json`);
+  }
+}
+
+function willBeImportedFromNodeModules(importPath: string) {
+  try {
+    const resolvedPath = require.resolve(importPath);
+    return resolvedPath.includes("node_modules");
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
このプラグインには大変お世話になってます！
（またuhyoさんのさまざまな記事もいつも大変楽しく読ませていただいております、ありがとうございます :raised_hands: ）

## 問題

`defaultImportability`というオプションが追加されたのを知りすぐに飛びついてしまいました！！！！
ただ、`defaultImportability`を`package`にしてみたところ、`package.json`に`main`フィールドなどのエントリーポイントがないパッケージ（例えば[`type-fest`](https://github.com/sindresorhus/type-fest/blob/main/package.json)）ではエラーになってしまうことに気づきました 😞 
インポートする対象が`node_modules`配下かどうかの判定にあたって[`require.resolve()`](https://github.com/uhyo/eslint-plugin-import-access/blob/master/src/rules/jsdoc.ts#L130)を使用していますが、`package.json`にエントリーポイントが指定されていないとパスの解決ができないようです。

## 解決策

```js
require.resolve(importPath);
```

でパスの解決ができない場合、

```js
require.resolve(`${importPath}/package.json`);
```

というようにパッケージ直下の`package.json`へのパスの解決を試みるように変更しています。
`node_modules`配下のパッケージであれば`package.json`を持っているはずなので、これをもって「`node_modules`配下のパッケージかどうか」の判定ができると考えました。

## テストについて

今回のケースについてのテストを追加する上で、「`package.json`に`main`フィールドなどのエントリーポイントがないパッケージ」を用意する必要があります。
`type-fest`などを`devDependencies`に追加することも考えましたが、`type-fest`側にアップデートが加わり`package.json`にエントリーポイントが追加されたりするとあとあと面倒に感じたので、このリポジトリ内で完結させました。
`src/__tests__/fixtures/packages/missing_entrypoint`にテスト用のパッケージを用意し、以下のコマンドによって`node_modules`配下にインストールしています。

```sh
npm i -D --install-links ./src/__tests__/fixtures/packages/missing_entrypoint
```

ディレクトリ構造だったり命名だったり、そもそもこのやり方自体についてなど何かよくない点ありましたら修正します！