### PR TITLE
Fix issue when importing Node.js builtin modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "lint": "eslint src/**/*.ts",
-    "test": "jest",
+    "test": "tsc -p src/__tests__/fixtures/project/tsconfig.json --noEmit && jest",
     "test:watch": "jest --watch"
   },
   "keywords": [

--- a/src/__tests__/default-export.ts
+++ b/src/__tests__/default-export.ts
@@ -136,4 +136,12 @@ describe("default export", () => {
     });
     expect(result).toMatchInlineSnapshot(`Array []`);
   });
+  it("No error for Node.js builtin modules with defaultImportability=package ", async () => {
+    const result = await tester.lintFile("src/default-export4/foo.ts", {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`Array []`);
+  });
 });

--- a/src/__tests__/fixtures/project/src/default-export4/foo.ts
+++ b/src/__tests__/fixtures/project/src/default-export4/foo.ts
@@ -1,0 +1,5 @@
+import path1 from "node:path";
+import path2 from "path";
+
+console.log(path1);
+console.log(path2);

--- a/src/__tests__/fixtures/project/tsconfig.json
+++ b/src/__tests__/fixtures/project/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "esModuleInterop": true
   },
   "include": ["./src/**/*.ts"]
 }

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -146,6 +146,11 @@ function willBeImportedFromNodeModules(importPath: string): boolean {
     return resolvedPath.includes("/node_modules/");
   } catch {
     if (!importPath.endsWith("/package.json")) {
+      /**
+       * Some library has no entrypoint in package.json such as `main` field.
+       * (For example, a library which provides .d.ts file only via `types` field.)
+       * In this case require.resolve("library") fails, so we try to call require.resolve("library/package.json") instead.
+       */
       return willBeImportedFromNodeModules(`${importPath}/package.json`);
     }
     return false;

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -125,10 +125,25 @@ function checkNodeModulesPackageOrNot(
 ) {
   if (node.parent?.type === "ImportDeclaration") {
     const packageName = node.parent.source.value;
+    if (isNodeBuiltinModule(packageName)) {
+      return true;
+    }
     if (willBeImportedFromNodeModules(packageName)) {
       return true;
     }
     return willBeImportedFromNodeModules(`${packageName}/package.json`);
+  }
+}
+
+function isNodeBuiltinModule(importPath: string) {
+  if (importPath.startsWith("node:")) {
+    return true;
+  }
+  try {
+    require.resolve(`node:${importPath}`);
+    return true;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
[`import path from 'path';`がエラーになる件](https://twitter.com/okunokentaro/status/1662763128357285888?s=61&t=q5R5v1TokpBNoR6fhk7OLQ)について、簡単ではありますが修正案を出します。

ただ、テストで動作確認していたところ、そもそも修正を入れずとも現行のコードで`import path from 'path';`は「テスト上は」エラーになりませんでした。
（ただ実際のコードベースで動作させると報告にあったようなエラーは確認できました。）

このPRで加えた変更により、実際のコードベースでのエラーも解消するのは確認できましたが、実際の環境での結果とテスト環境での結果が一致しないのはどうなんだろうと思い、一旦DraftとしてPRを出してみます。

何かこのあたり原因に検討つきますでしょうか・・・？
（`defaultImportability`という素晴らしいオプションを実装してくださった @seito2 さんももしかしたらこの件に取り組まれているかもしれないので、周知の意味を込めてちょっとメンションさせていただきます:bow:）