### PR TITLE
Forbid re-exports of non-importable variables

### DIFF
--- a/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub.ts
@@ -1,0 +1,1 @@
+export { subFoo } from "./sub/foo";

--- a/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub/foo.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub/foo.ts
@@ -1,0 +1,4 @@
+/**
+ * @package
+ */
+export const subFoo = "hello!";

--- a/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub2.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/filenameLoophole/sub2.ts
@@ -1,0 +1,1 @@
+export { subFoo } from "./sub/foo";

--- a/src/__tests__/fixtures/project/src/reexport4/indexLoophole/reexportFromSubFoo.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/indexLoophole/reexportFromSubFoo.ts
@@ -1,0 +1,1 @@
+export { subFoo } from "./sub/foo";

--- a/src/__tests__/fixtures/project/src/reexport4/indexLoophole/reexportFromSubIndex.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/indexLoophole/reexportFromSubIndex.ts
@@ -1,0 +1,1 @@
+export { subFoo } from "./sub/index";

--- a/src/__tests__/fixtures/project/src/reexport4/indexLoophole/sub/foo.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/indexLoophole/sub/foo.ts
@@ -1,0 +1,4 @@
+/**
+ * @package
+ */
+export const subFoo = "hello!";

--- a/src/__tests__/fixtures/project/src/reexport4/indexLoophole/sub/index.ts
+++ b/src/__tests__/fixtures/project/src/reexport4/indexLoophole/sub/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @package
+ */
+export { subFoo } from "./foo";

--- a/src/__tests__/reexport.ts
+++ b/src/__tests__/reexport.ts
@@ -43,6 +43,32 @@ Array [
 ]
 `);
   });
+  it("Cannot re-export a package-private variable", async () => {
+    const result = await tester.lintFile(
+      "src/reexport4/indexLoophole/reexportFromSubFoo.ts"
+    );
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "column": 10,
+    "endColumn": 16,
+    "endLine": 1,
+    "line": 1,
+    "message": "Cannot re-export a package-private export 'subFoo'",
+    "messageId": "package:reexport",
+    "nodeType": "ExportSpecifier",
+    "ruleId": "import-access/jsdoc",
+    "severity": 2,
+  },
+]
+`);
+  });
+  it("Can re-export a variable exported from index.ts", async () => {
+    const result = await tester.lintFile(
+      "src/reexport4/indexLoophole/reexportFromSubIndex.ts"
+    );
+    expect(result).toMatchInlineSnapshot(`Array []`);
+  });
   describe("indexLoophole = false", () => {
     it("Cannot import a package-private variable from sub/index.ts", async () => {
       const result = await tester.lintFile("src/reexport/useFoo.ts", {
@@ -77,6 +103,31 @@ Array [
 ]
 `);
     });
+    it("Cannot re-export a package-private variable", async () => {
+      const result = await tester.lintFile(
+        "src/reexport4/indexLoophole/reexportFromSubIndex.ts",
+        {
+          jsdoc: {
+            indexLoophole: false,
+          },
+        }
+      );
+      expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "column": 10,
+    "endColumn": 16,
+    "endLine": 1,
+    "line": 1,
+    "message": "Cannot re-export a package-private export 'subFoo'",
+    "messageId": "package:reexport",
+    "nodeType": "ExportSpecifier",
+    "ruleId": "import-access/jsdoc",
+    "severity": 2,
+  },
+]
+`);
+    });
   });
   describe("filenameLoophole = true", () => {
     it("Can import from sub directory of same name", async () => {
@@ -96,6 +147,44 @@ Array [
     "message": "Cannot import a package-private export 'subBar'",
     "messageId": "package",
     "nodeType": "ImportSpecifier",
+    "ruleId": "import-access/jsdoc",
+    "severity": 2,
+  },
+]
+`);
+    });
+    it("Can re-export from sub directory of same name", async () => {
+      const result = await tester.lintFile(
+        "src/reexport4/filenameLoophole/sub.ts",
+        {
+          jsdoc: {
+            indexLoophole: false,
+            filenameLoophole: true,
+          },
+        }
+      );
+      expect(result).toMatchInlineSnapshot(`Array []`);
+    });
+    it("Cannot re-export from sub directory of different name", async () => {
+      const result = await tester.lintFile(
+        "src/reexport4/filenameLoophole/sub2.ts",
+        {
+          jsdoc: {
+            indexLoophole: false,
+            filenameLoophole: true,
+          },
+        }
+      );
+      expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "column": 10,
+    "endColumn": 16,
+    "endLine": 1,
+    "line": 1,
+    "message": "Cannot re-export a package-private export 'subFoo'",
+    "messageId": "package:reexport",
+    "nodeType": "ExportSpecifier",
     "ruleId": "import-access/jsdoc",
     "severity": 2,
   },


### PR DESCRIPTION
連日でPRを投げて騒がしくしてしまいすみません :sob:

現時点で以下のような記述ができますが、

```ts
// Cannot import a private export 'subFoo'
import { subFoo } from "./sub/foo";

// No error
export { subFoo } from "./sub/foo";
```

「あるファイルからインポートできないものは再エクスポートもできない」という挙動の方がこのプラグインでガチガチに縛ろうとしたときには価値を発揮するかなと個人的には思ったのですが、いかがでしょうか・・・？

また、もしこの変更を導入する場合にはプラグインのオプションを追加してユーザーがオプトインできる形の方がいいのかも、ということもちょっと思ってはいますが、その辺ももしご意見あれば頂けると幸いでございます :pray:
（別の観点として、プラグイン名としては`import-access`の制御を担っており、こういった`export`宣言についてのチェックは本来のスコープ外のようにも思えるので、その意味でもオプトインの方が好ましいのかなと思ったり）