### PR TITLE
fix: support scoped package

### DIFF
--- a/src/__tests__/fixtures/project/package.json
+++ b/src/__tests__/fixtures/project/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "project",
+  "name": "@uhyo/project",
   "private": true,
   "exports": {
     "./self-reference": "./src/self-reference/index.js"

--- a/src/__tests__/fixtures/project/src/self-reference/user.ts
+++ b/src/__tests__/fixtures/project/src/self-reference/user.ts
@@ -1,3 +1,3 @@
-import { exportedValue } from "project/self-reference";
+import { exportedValue } from "@uhyo/project/self-reference";
 
 console.log(exportedValue);

--- a/src/core/checkSymbolmportability.ts
+++ b/src/core/checkSymbolmportability.ts
@@ -36,15 +36,11 @@ export function checkSymbolImportability(
 
   if (packageOptions.treatSelfReferenceAs === "external") {
     // Check whether this import is the result of a self-reference.
-    const match = possibleSubpathImportFromPackage.exec(moduleSpecifier);
-    if (match) {
-      const packageName = match[1];
-      const lookupResult = lookupPackageJson(importerFilename);
-      if (lookupResult !== null) {
-        if (lookupResult.packageJson.name === packageName) {
-          // This is a self-reference, so treat as external.
-          return;
-        }
+    const lookupResult = lookupPackageJson(importerFilename);
+    if (lookupResult !== null) {
+      if (moduleSpecifier.startsWith(lookupResult.packageJson.name)) {
+        // This is a self-reference, so treat as external.
+        return;
       }
     }
   }
@@ -95,6 +91,3 @@ export function checkSymbolImportability(
   );
   return inPackage ? undefined : "package";
 }
-
-const possibleSubpathImportFromPackage =
-  /^(?![./\\])([^/\\]*)(?:$|[/\\][^/\\])/;

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -65,6 +65,10 @@ const jsdocRule: Omit<
             type: "string",
             enum: ["public", "package", "private"],
           },
+          treatSelfReferenceAs: {
+            type: "string",
+            enum: ["external", "internal"],
+          }
         },
         additionalProperties: false,
       },


### PR DESCRIPTION
Hi. thank you for the release of `treatSelfReferenceAs`!
However, I found that it doesn't work well when given package name is scoped (like `@vanilla-extract/css`).