### PR TITLE
fix bug check package incorrect on Windows

### DIFF
--- a/src/utils/isInPackage.ts
+++ b/src/utils/isInPackage.ts
@@ -10,7 +10,7 @@ export type PackageOptions = {
 // ../ or ../../ or ...
 const ancestorDirRegExp = new RegExp(`^(?:\\.\\.\\${path.sep})*(?:\\.\\.)?$`);
 
-const indexFileRegExp = new RegExp(`\\${path.sep}index\\.[cm]?[jt]sx?$`);
+const indexFileRegExp = new RegExp(`\\/index\\.[cm]?[jt]sx?$`);
 
 /**
  * Checks whether importer is in the same 'package' as exporter.


### PR DESCRIPTION
Because the exporter (decl.getSourceFile().fileName) always has slashes (/) in the path regardless of the OS.
Ex:
Mac: /Users/project/src/pages/A/B/C/D/name.tsx
Win: D:/project/src/pages/A/B/C/D/name.tsx

Therefore, it is necessary to hardcode the slash character (/) in the regex to get the correct result on the Windows environment.