### PR TITLE
feat: support Flat Config support (non-breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,37 @@ This package solves this problem by providing a new directory-level layer and en
 npm i -D eslint-plugin-import-access
 ```
 
+Depending on how you configure ESLint, use either Flat Config or eslintrc to configure eslint-plugin-import-access.
+
+Also, you can enable the TypeScript Language Service Plugin by adding it to the `plugins` array in `tsconfig.json`.
+
+### Flat Config
+
+In **eslint.config.js**:
+
+```js
+import importAccess from "eslint-plugin-import-access/flat-config";
+
+export default [
+  // other settings...
+  // (you also need to set up typescript-eslint)
+  {
+    plugins: {
+      "import-access": importAccess,
+    },
+  },
+  {
+    rules: {
+      "import-access/jsdoc": ["error"],
+    },
+  },
+];
+```
+
+_Note: currently you need to import the plugin from the `/flat-config` subpath. In a future version, this will be simplified._
+
+### eslintrc
+
 In **.eslintrc.js**:
 
 ```js
@@ -31,6 +62,8 @@ In **.eslintrc.js**:
     "import-access/jsdoc": ["error"],
   }
 ```
+
+### TypeScript Language Service Plugin
 
 In **tsconfig.json**:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "exports": {
     "./ts-plugin": "./dist/ts-plugin.js",
+    "./flat-config": {
+      "import": "./dist/flat-config.mjs",
+      "require": "./dist/flat-config.cjs",
+      "default": "./dist/flat-config.cjs"
+    },
     ".": "./dist/index.js"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.1.2",
   "description": "ESLint rule for prohibiting package-private imports",
   "main": "dist/index.js",
+  "exports": {
+    "./ts-plugin": "./dist/ts-plugin.js",
+    ".": "./dist/index.js"
+  },
   "files": [
     "dist",
     "!dist/__tests__"

--- a/src/flat-config.cts
+++ b/src/flat-config.cts
@@ -1,0 +1,22 @@
+import jsdoc from "./rules/jsdoc";
+
+/**
+ * ESLint Plugin object of eslint-plugin-import-access.
+ */
+const eslintPlugin = {
+  rules: {
+    jsdoc: jsdoc as unknown,
+  },
+  configs: {
+    all: {} as unknown,
+  },
+};
+
+eslintPlugin.configs.all = {
+  plugins: { "import-access": eslintPlugin },
+  rules: {
+    "import-access/jsdoc": "error",
+  },
+};
+
+export = eslintPlugin;

--- a/src/flat-config.cts
+++ b/src/flat-config.cts
@@ -7,16 +7,6 @@ const eslintPlugin = {
   rules: {
     jsdoc: jsdoc as unknown,
   },
-  configs: {
-    all: {} as unknown,
-  },
-};
-
-eslintPlugin.configs.all = {
-  plugins: { "import-access": eslintPlugin },
-  rules: {
-    "import-access/jsdoc": "error",
-  },
 };
 
 export = eslintPlugin;

--- a/src/flat-config.mts
+++ b/src/flat-config.mts
@@ -1,0 +1,3 @@
+import eslintPlugin from "./flat-config.cjs";
+
+export default eslintPlugin;

--- a/src/ts-plugin.ts
+++ b/src/ts-plugin.ts
@@ -1,0 +1,3 @@
+import { tsServerPluginInit } from "./ts-server-plugin";
+
+export = tsServerPluginInit;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,17 +4,17 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "node16",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "node16" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -25,7 +25,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -42,14 +42,14 @@
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
 
     /* Module Resolution Options */
-    "moduleResolution": "node16",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node16" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -64,8 +64,8 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
This PR enables importing from `eslint-plugin-import-access/flat-config` for using eslint-plugin-import-access with Flat Config.

We plan to export Flat Config form the main `eslint-plugin-import-access` endpoint, but that will be a breaking change and will be done later.

see #18.