### PR TITLE
feat: add excludeSourcePatterns option to import-access/jsdoc rule

### DIFF
--- a/docs/rule-jsdoc.md
+++ b/docs/rule-jsdoc.md
@@ -193,7 +193,7 @@ When `treatSelfReferenceAs: internal`, this import is disallowed because import 
 
 _Default value: `[]`_
 
-An array of glob patterns for source paths to exclude from the importability check. When importing from a module that matches one of these patterns, the import-access/jsdoc rule will not apply any restrictions, regardless of the JSDoc annotations or defaultImportability setting.
+An array of glob patterns for source paths to exclude from the importability check. The patterns are resolved relative to the project root. When importing from a module that matches one of these patterns, the import-access/jsdoc rule will not apply any restrictions, regardless of the JSDoc annotations or defaultImportability setting.
 
 This is particularly useful for handling imports from auto-generated files that don't have proper JSDoc annotations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@typescript-eslint/utils": "^8.4.0",
+        "minimatch": "^10.0.1",
         "tsutils": "^3.21.0"
       },
       "devDependencies": {
@@ -3036,6 +3037,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -6544,14 +6560,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@typescript-eslint/utils": "^8.4.0",
+    "minimatch": "^10.0.1",
     "tsutils": "^3.21.0"
   },
   "devDependencies": {

--- a/src/__tests__/exclude-patterns.ts
+++ b/src/__tests__/exclude-patterns.ts
@@ -1,0 +1,45 @@
+import { getESLintTester } from "./fixtures/eslint";
+
+const tester = getESLintTester();
+
+it("Importing from generated package is disallowed by default", async () => {
+  const result = await tester.lintFile(
+    "src/exclude-patterns/generated-type-user.ts",
+    {
+      jsdoc: {
+        defaultImportability: "package",
+      },
+    },
+  );
+  expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "column": 10,
+    "endColumn": 19,
+    "endLine": 1,
+    "line": 1,
+    "message": "Cannot import a package-private export 'someValue'",
+    "messageId": "package",
+    "nodeType": "ImportSpecifier",
+    "ruleId": "import-access/jsdoc",
+    "severity": 2,
+  },
+]
+`);
+});
+
+it("Importing from generated package is allowed with excludeSourcePatterns targeting the file path (relative path)", async () => {
+  const result = await tester.lintFile(
+    "src/exclude-patterns/generated-type-user.ts",
+    {
+      jsdoc: {
+        defaultImportability: "package",
+        excludeSourcePatterns: [
+          // exclude the types file
+          "src/__tests__/fixtures/project/src/exclude-patterns/types/**",
+        ],
+      },
+    },
+  );
+  expect(result).toMatchInlineSnapshot(`Array []`);
+});

--- a/src/__tests__/fixtures/project/src/exclude-patterns/generated-type-user.ts
+++ b/src/__tests__/fixtures/project/src/exclude-patterns/generated-type-user.ts
@@ -1,0 +1,3 @@
+import { someValue } from "generated-package";
+
+console.log(someValue);

--- a/src/__tests__/fixtures/project/src/exclude-patterns/types/types.d.ts
+++ b/src/__tests__/fixtures/project/src/exclude-patterns/types/types.d.ts
@@ -1,0 +1,3 @@
+declare module "generated-package" {
+  export const someValue: string;
+}

--- a/src/rules/jsdoc.ts
+++ b/src/rules/jsdoc.ts
@@ -30,6 +30,11 @@ export type JSDocRuleOptions = {
    * the importability check.
    */
   treatSelfReferenceAs: "internal" | "external";
+  /**
+   * Array of glob patterns for source paths to exclude from the importability check.
+   * Useful for excluding generated files or auto-generated type definitions.
+   */
+  excludeSourcePatterns?: string[];
 };
 
 const jsdocRule: Omit<
@@ -70,6 +75,12 @@ const jsdocRule: Omit<
             type: "string",
             enum: ["external", "internal"],
           },
+          excludeSourcePatterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
         },
         additionalProperties: false,
       },
@@ -81,6 +92,7 @@ const jsdocRule: Omit<
       filenameLoophole: false,
       defaultImportability: "public",
       treatSelfReferenceAs: "external",
+      excludeSourcePatterns: [],
     },
   ],
   create(context) {
@@ -94,6 +106,7 @@ const jsdocRule: Omit<
       filenameLoophole,
       defaultImportability,
       treatSelfReferenceAs,
+      excludeSourcePatterns,
     } = jsDocRuleDefaultOptions(options[0]);
 
     const packageOptions: PackageOptions = {
@@ -101,6 +114,7 @@ const jsdocRule: Omit<
       filenameLoophole,
       defaultImportability,
       treatSelfReferenceAs,
+      excludeSourcePatterns,
     };
 
     return {
@@ -249,12 +263,14 @@ export function jsDocRuleDefaultOptions(
     filenameLoophole = false,
     defaultImportability = "public",
     treatSelfReferenceAs = "external",
+    excludeSourcePatterns = [],
   } = options || {};
   return {
     indexLoophole,
     filenameLoophole,
     defaultImportability,
     treatSelfReferenceAs,
+    excludeSourcePatterns,
   };
 }
 

--- a/src/utils/isInPackage.ts
+++ b/src/utils/isInPackage.ts
@@ -5,6 +5,7 @@ export type PackageOptions = {
   readonly filenameLoophole: boolean;
   readonly defaultImportability: "public" | "package" | "private";
   readonly treatSelfReferenceAs: "internal" | "external";
+  readonly excludeSourcePatterns?: readonly string[];
 };
 
 // ../ or ../../ or ...


### PR DESCRIPTION
Closes #124

This PR adds a new `excludeSourcePatterns` option to the `import-access/jsdoc` rule.

## Implementation

- Added `excludeSourcePatterns` option to `JSDocRuleOptions`
- Enhanced `checkSymbolImportability` to check source paths against patterns
- Added documentation and tests


The change is fully backward compatible as it's an optional feature.



## Example

```js
// .eslintrc.js
{
  "rules": {
    "import-access/jsdoc": ["error", {
      "defaultImportability": "package",
      "excludeSourcePatterns": [
        ".next/**/*",
        "**/*.generated.*"
      ]
    }]
  }
}
```

## Verification

We can verify this PR works as expected using the minimal reproduction repository from issue #124:

```bash
git clone https://github.com/ygkn/eslint-plugin-import-access-do-not-work-with-next.git
cd eslint-plugin-import-access-do-not-work-with-next

# Run `npm run build` at this repo checkouted this pr
npm install -D file:/path/to/local/clone/of/this/pr
```

Add option to eslint.config.mjs:

```diff js
    {
      rules: {
        "import-access/jsdoc": [
          "error",
          {
            defaultImportability: "package",
+           excludeSourcePatterns: [
+             ".next/**/*",
+           ],
          },
        ],
      },
    },
```

We get only expected errors.

```
❯ npm run lint

> lint
> next lint


./src/app/test-import.tsx
4:10  Error: Cannot import a package-private export 'formatDate'  import-access/jsdoc

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
```


## Dependencies

Added `minimatch` (v10.0.1) for glob pattern matching. This is already used in the ecosystem:

- ESLint itself uses `minimatch` (v3.1.2)
- TypeScript-ESLint uses `minimatch` in its parser

```
❯ npm ls minimatch
eslint-plugin-import-access@2.2.2
├─┬ @typescript-eslint/typescript-estree@8.4.0
│ └── minimatch@9.0.5
├─┬ babel-jest@29.7.0
│ └─┬ babel-plugin-istanbul@6.1.1
│   └─┬ test-exclude@6.0.0
│     ├─┬ glob@7.2.3
│     │ └── minimatch@3.1.2
│     └── minimatch@3.1.2
├─┬ eslint@8.57.0
│ ├─┬ @eslint/eslintrc@2.1.4
│ │ └── minimatch@3.1.2
│ ├─┬ @humanwhocodes/config-array@0.11.14
│ │ └── minimatch@3.1.2
│ └── minimatch@3.1.2
└── minimatch@10.0.1
```


## Alternative Approach

If adding `minimatch` as a dependency is a concern, we could implement a regex-based approach instead:

```ts
// Using regex patterns instead of glob patterns
excludeSourceRegexps?: RegExp[];

// Usage in checkSymbolImportability:
if (packageOptions.excludeSourceRegexps?.some(regex => regex.test(relativePath))) {
  // Skip importability check
  return;
}
```

This would avoid the external dependency, though glob patterns are more user-friendly and consistent with ESLint's existing pattern syntax.
