### PR TITLE
chore(deps): prevent duplicate PRs for @typescript-eslint packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     ignore:
       - dependency-name: "@types/node"
     groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+        update-types:
+          - "minor"
+          - "patch"
       minors:
         dependency-type: "production"
         update-types:


### PR DESCRIPTION
## Summary

- Created a dedicated `typescript-eslint` group for all `@typescript-eslint/*` packages
- This prevents these packages from matching both the `minors` (production) and `minors-dev` (development) groups
- Resolves the issue where Dependabot was opening duplicate pull requests for `@typescript-eslint/utils`

## Changes

Added a new group in `.github/dependabot.yml` that matches all `@typescript-eslint/*` packages regardless of dependency type. Since groups are evaluated in order and the first match wins, this group is placed before the general `minors` and `minors-dev` groups.

## Test plan

- Wait for Dependabot to process updates
- Verify that `@typescript-eslint/*` package updates result in a single PR instead of two

🤖 Generated with [Claude Code](https://claude.com/claude-code)